### PR TITLE
Add Employment Data methods to the Client

### DIFF
--- a/lib/identity-api-client.rb
+++ b/lib/identity-api-client.rb
@@ -7,12 +7,16 @@ require 'identity-api-client/mailing_api_base'
 
 require 'identity-api-client/actions'
 require 'identity-api-client/client'
+require 'identity-api-client/employment_data'
+require 'identity-api-client/industries'
 require 'identity-api-client/lists'
 require 'identity-api-client/mailing'
 require 'identity-api-client/mailings'
 require 'identity-api-client/member'
+require 'identity-api-client/professions'
 require 'identity-api-client/search'
 require 'identity-api-client/searches'
+require 'identity-api-client/workplaces'
 
 module IdentityApiClient
   extend Vertebrae::Base

--- a/lib/identity-api-client/client.rb
+++ b/lib/identity-api-client/client.rb
@@ -34,6 +34,22 @@ module IdentityApiClient
       @lists ||= IdentityApiClient::Lists.new(client: self)
     end
 
+    def employment_data
+      @employment_data ||= IdentityApiClient::EmploymentData.new(client: self)
+    end
+
+    def workplaces
+      @workplaces ||= IdentityApiClient::Workplaces.new(client: self)
+    end
+
+    def industries
+      @industries ||= IdentityApiClient::Industries.new(client: self)
+    end
+
+    def professions
+      @professions ||= IdentityApiClient::Professions.new(client: self)
+    end
+
     private
 
     def extract_data_from_params(params)

--- a/lib/identity-api-client/employment_data.rb
+++ b/lib/identity-api-client/employment_data.rb
@@ -1,7 +1,7 @@
 module IdentityApiClient
   class EmploymentData < Base
     def list
-      resp = client.get_request(route_url("/api/employment?api_token=#{client.connection.configuration.options[:api_token]}"))
+      resp = client.get_request("/api/employment?api_token=#{client.connection.configuration.options[:api_token]}")
       if resp.status == 200
         return EmploymentDataResult.new(resp.body)
       else

--- a/lib/identity-api-client/employment_data.rb
+++ b/lib/identity-api-client/employment_data.rb
@@ -1,0 +1,29 @@
+module IdentityApiClient
+  class EmploymentData < Base
+    def list
+      resp = client.get_request(route_url("/api/employment?api_token=#{client.connection.configuration.options[:api_token]}"))
+      if resp.status == 200
+        return EmploymentDataResult.new(resp.body)
+      else
+        return false
+      end
+    end
+  end
+
+  class EmploymentDataResult
+    attr_reader :employment_statuses, :approved_workplaces, :approved_industries, :approved_professions
+
+    def initialize(body)
+      @employment_statuses = body.employment_statuses.map.with_index do |employment_status, i|
+        {
+          slug: employment_status,
+          label: body.employment_status_labels[i]
+        }
+      end
+
+      @approved_workplaces = body.workplaces
+      @approved_industries = body.industries
+      @approved_professions = body.professions
+    end
+  end
+end

--- a/lib/identity-api-client/employment_data.rb
+++ b/lib/identity-api-client/employment_data.rb
@@ -14,11 +14,8 @@ module IdentityApiClient
     attr_reader :employment_statuses, :approved_workplaces, :approved_industries, :approved_professions
 
     def initialize(body)
-      @employment_statuses = body.employment_statuses.map.with_index do |employment_status, i|
-        {
-          slug: employment_status,
-          label: body.employment_status_labels[i]
-        }
+      @employment_statuses = body.employment_status_labels.map do |slug, label|
+        { slug: slug, label: label }
       end
 
       @approved_workplaces = body.workplaces

--- a/lib/identity-api-client/industries.rb
+++ b/lib/identity-api-client/industries.rb
@@ -1,7 +1,7 @@
 module IdentityApiClient
   class Industries < Base
     def list
-      resp = client.get_request(route_url("/api/industries?api_token=#{client.connection.configuration.options[:api_token]}"))
+      resp = client.get_request("/api/industries?api_token=#{client.connection.configuration.options[:api_token]}")
       if resp.status == 200
         return resp.body
       else
@@ -10,7 +10,7 @@ module IdentityApiClient
     end
 
     def approved
-      resp = client.get_request(route_url("/api/industries/approved?api_token=#{client.connection.configuration.options[:api_token]}"))
+      resp = client.get_request("/api/industries/approved?api_token=#{client.connection.configuration.options[:api_token]}")
       if resp.status == 200
         return resp.body
       else
@@ -23,7 +23,7 @@ module IdentityApiClient
         'api_token' => client.connection.configuration.options[:api_token],
         'industry' => industry
       }
-      resp = client.post_request(route_url('/api/industries'), params)
+      resp = client.post_request('/api/industries', params)
       if resp.status < 400
         return resp.body
       else

--- a/lib/identity-api-client/industries.rb
+++ b/lib/identity-api-client/industries.rb
@@ -1,0 +1,34 @@
+module IdentityApiClient
+  class Industries < Base
+    def list
+      resp = client.get_request(route_url("/api/industries?api_token=#{client.connection.configuration.options[:api_token]}"))
+      if resp.status == 200
+        return resp.body
+      else
+        return false
+      end
+    end
+
+    def approved
+      resp = client.get_request(route_url("/api/industries/approved?api_token=#{client.connection.configuration.options[:api_token]}"))
+      if resp.status == 200
+        return resp.body
+      else
+        return false
+      end
+    end
+
+    def create(industry)
+      params = {
+        'api_token' => client.connection.configuration.options[:api_token],
+        'industry' => industry
+      }
+      resp = client.post_request(route_url('/api/industries'), params)
+      if resp.status < 400
+        return resp.body
+      else
+        return resp.body['errors']
+      end
+    end
+  end
+end

--- a/lib/identity-api-client/industries.rb
+++ b/lib/identity-api-client/industries.rb
@@ -24,7 +24,7 @@ module IdentityApiClient
         'industry' => industry
       }
       resp = client.post_request('/api/industries', params)
-      if resp.status < 400
+      if resp.status == 200
         return resp.body
       else
         return resp.body['errors']

--- a/lib/identity-api-client/member.rb
+++ b/lib/identity-api-client/member.rb
@@ -1,6 +1,6 @@
 module IdentityApiClient
   class Member < Base
-    def details(guid: nil, email: nil, load_current_consents: false)
+    def details(guid: nil, email: nil, load_current_consents: false, load_employment: false)
       if guid.present?
         params = {'guid' => guid, 'api_token' => client.connection.configuration.options[:api_token]}
       elsif email.present?
@@ -11,6 +11,10 @@ module IdentityApiClient
 
       if load_current_consents
         params['load_current_consents'] = true
+      end
+
+      if load_employment
+        params['load_employment'] = true
       end
 
       resp = client.post_request('/api/member/details', params)

--- a/lib/identity-api-client/professions.rb
+++ b/lib/identity-api-client/professions.rb
@@ -15,7 +15,7 @@ module IdentityApiClient
         'profession' => profession
       }
       resp = client.post_request('/api/professions', params)
-      if resp.status < 400
+      if resp.status == 200
         return resp.body
       else
         return resp.body['errors']

--- a/lib/identity-api-client/professions.rb
+++ b/lib/identity-api-client/professions.rb
@@ -1,7 +1,7 @@
 module IdentityApiClient
   class Professions < Base
     def list
-      resp = client.get_request(route_url("/api/professions?api_token=#{client.connection.configuration.options[:api_token]}"))
+      resp = client.get_request("/api/professions?api_token=#{client.connection.configuration.options[:api_token]}")
       if resp.status == 200
         return resp.body
       else
@@ -14,7 +14,7 @@ module IdentityApiClient
         'api_token' => client.connection.configuration.options[:api_token],
         'profession' => profession
       }
-      resp = client.post_request(route_url('/api/professions'), params)
+      resp = client.post_request('/api/professions', params)
       if resp.status < 400
         return resp.body
       else

--- a/lib/identity-api-client/professions.rb
+++ b/lib/identity-api-client/professions.rb
@@ -1,0 +1,25 @@
+module IdentityApiClient
+  class Professions < Base
+    def list
+      resp = client.get_request(route_url("/api/professions?api_token=#{client.connection.configuration.options[:api_token]}"))
+      if resp.status == 200
+        return resp.body
+      else
+        return false
+      end
+    end
+
+    def create(profession)
+      params = {
+        'api_token' => client.connection.configuration.options[:api_token],
+        'profession' => profession
+      }
+      resp = client.post_request(route_url('/api/professions'), params)
+      if resp.status < 400
+        return resp.body
+      else
+        return resp.body['errors']
+      end
+    end
+  end
+end

--- a/lib/identity-api-client/workplaces.rb
+++ b/lib/identity-api-client/workplaces.rb
@@ -24,7 +24,7 @@ module IdentityApiClient
         'workplace' => workplace
       }
       resp = client.post_request('/api/workplaces', params)
-      if resp.status < 400
+      if resp.status == 200
         return resp.body
       else
         return resp.body['errors']

--- a/lib/identity-api-client/workplaces.rb
+++ b/lib/identity-api-client/workplaces.rb
@@ -1,0 +1,34 @@
+module IdentityApiClient
+  class Workplaces < Base
+    def list
+      resp = client.get_request(route_url("/api/workplaces?api_token=#{client.connection.configuration.options[:api_token]}"))
+      if resp.status == 200
+        return resp.body
+      else
+        return false
+      end
+    end
+
+    def approved
+      resp = client.get_request(route_url("/api/workplaces/approved?api_token=#{client.connection.configuration.options[:api_token]}"))
+      if resp.status == 200
+        return resp.body
+      else
+        return false
+      end
+    end
+
+    def create(workplace)
+      params = {
+        'api_token' => client.connection.configuration.options[:api_token],
+        'workplace' => workplace
+      }
+      resp = client.post_request(route_url('/api/workplaces'), params)
+      if resp.status < 400
+        return resp.body
+      else
+        return resp.body['errors']
+      end
+    end
+  end
+end

--- a/lib/identity-api-client/workplaces.rb
+++ b/lib/identity-api-client/workplaces.rb
@@ -1,7 +1,7 @@
 module IdentityApiClient
   class Workplaces < Base
     def list
-      resp = client.get_request(route_url("/api/workplaces?api_token=#{client.connection.configuration.options[:api_token]}"))
+      resp = client.get_request("/api/workplaces?api_token=#{client.connection.configuration.options[:api_token]}")
       if resp.status == 200
         return resp.body
       else
@@ -10,7 +10,7 @@ module IdentityApiClient
     end
 
     def approved
-      resp = client.get_request(route_url("/api/workplaces/approved?api_token=#{client.connection.configuration.options[:api_token]}"))
+      resp = client.get_request("/api/workplaces/approved?api_token=#{client.connection.configuration.options[:api_token]}")
       if resp.status == 200
         return resp.body
       else
@@ -23,7 +23,7 @@ module IdentityApiClient
         'api_token' => client.connection.configuration.options[:api_token],
         'workplace' => workplace
       }
-      resp = client.post_request(route_url('/api/workplaces'), params)
+      resp = client.post_request('/api/workplaces', params)
       if resp.status < 400
         return resp.body
       else


### PR DESCRIPTION
Adds the following methods to the client:

```ruby
employement_data = client.employment_data.list

employement_data.employment_statuses
 => [{:slug=>"not_set", :label=>"not set"}, {:slug=>"employee", :label=>"Employed"}, {:slug=>"worker", :label=>"Worker"}, ...]

employement_data.approved_workplaces.first
 => #<Hashie::Mash approved=true created_at="2018-11-27T11:07:06.077+00:00" external_id=31 id=3032 industry_id=nil name="Ampersand" never_approve=nil registered_name=nil registration_id=nil similar_approved_workplace_id=nil similar_approved_workplace_name=nil slug="ampersand" updated_at="2021-02-25T11:36:58.756+00:00">
 
 employement_data.approved_industries.first
 => #<Hashie::Mash approved=true created_at="2020-12-17T19:45:57.318+00:00" id=12 member_count=62 name="Education" slug="education" updated_at="2021-06-23T13:53:11.898+01:00">

employement_data.approved_professions.first
 => #<Hashie::Mash approved=true created_at="2021-01-12T11:57:28.049+00:00" id=116 industry_id=nil name="Dummy workplace: Omqsdjzk" slug="dummyworkplace:omqsdjzk" updated_at="2021-02-05T19:41:36.608+00:00"> 
```

Also adds support for the individual `workplaces` / `industries` / `professions` endpoints.

Updates the `client.member.details` method to accept an optional `load_employment` argument (defaulted to `false`) - if present, the Identity API will also load employment data for the given member ([see here for the format of this data](https://github.com/the-open/identity/blob/c02067f0ad5e819c4a1549e001f18f31099897f9/app/controllers/api/member_controller.rb#L231)).