### PR TITLE
Add find_action_by_network_id to actions

### DIFF
--- a/lib/identity-api-client/actions.rb
+++ b/lib/identity-api-client/actions.rb
@@ -39,6 +39,18 @@ module IdentityApiClient
       end
     end
 
+    # This shares some logic with find_by above, but returns in the same format as the
+    # 'recent...' methods below.
+    #
+    def find_by_network_id(network_id)
+      resp = client.get_request("/api/actions/find_by_network_id", query: network_id)
+      if resp.status == 200
+        return resp.body
+      else
+        false
+      end
+    end
+
     # The following 'recent...' methods all use the same input params.
     #
     # If from_time is present, Identity will search for the relevant data starting at the

--- a/lib/identity-api-client/actions.rb
+++ b/lib/identity-api-client/actions.rb
@@ -43,7 +43,8 @@ module IdentityApiClient
     # 'recent...' methods below.
     #
     def find_by_network_id(network_id)
-      resp = client.get_request("/api/actions/find_by_network_id", query: {network_id: network_id})
+      query_params = {network_id: network_id, api_token: api_token}
+      resp = client.get_request("/api/actions/find_by_network_id", query_params)
       if resp.status == 200
         return resp.body
       else

--- a/lib/identity-api-client/actions.rb
+++ b/lib/identity-api-client/actions.rb
@@ -42,9 +42,13 @@ module IdentityApiClient
     # This shares some logic with find_by above, but returns in the same format as the
     # 'recent...' methods below.
     #
-    def find_by_network_id(network_id)
-      query_params = {network_id: network_id, api_token: api_token}
-      resp = client.get_request("/api/actions/find_by_network_id", query_params)
+    def find_by_external_id(external_id, external_system)
+      query_params = {
+        external_id: external_id,
+        external_system: external_system,
+        api_token: api_token
+      }
+      resp = client.get_request("/api/actions/find_by_external_id", query_params)
       if resp.status == 200
         return resp.body
       else

--- a/lib/identity-api-client/actions.rb
+++ b/lib/identity-api-client/actions.rb
@@ -43,7 +43,7 @@ module IdentityApiClient
     # 'recent...' methods below.
     #
     def find_by_network_id(network_id)
-      resp = client.get_request("/api/actions/find_by_network_id", query: network_id)
+      resp = client.get_request("/api/actions/find_by_network_id", query: {network_id: network_id})
       if resp.status == 200
         return resp.body
       else

--- a/lib/identity-api-client/actions.rb
+++ b/lib/identity-api-client/actions.rb
@@ -42,8 +42,8 @@ module IdentityApiClient
     # This shares some logic with find_by above, but returns in the same format as the
     # 'recent...' methods below.
     #
-    def find_by_network_id(network_id)
-      query_params = {network_id: network_id, api_token: api_token}
+    def find_by_network_id(network_id, excluded_action_types = nil)
+      query_params = {network_id: network_id, api_token: api_token, excluded_action_types: excluded_action_types}
       resp = client.get_request("/api/actions/find_by_network_id", query_params)
       if resp.status == 200
         return resp.body

--- a/lib/identity-api-client/actions.rb
+++ b/lib/identity-api-client/actions.rb
@@ -42,8 +42,8 @@ module IdentityApiClient
     # This shares some logic with find_by above, but returns in the same format as the
     # 'recent...' methods below.
     #
-    def find_by_network_id(network_id, excluded_action_types = nil)
-      query_params = {network_id: network_id, api_token: api_token, excluded_action_types: excluded_action_types}
+    def find_by_network_id(network_id)
+      query_params = {network_id: network_id, api_token: api_token}
       resp = client.get_request("/api/actions/find_by_network_id", query_params)
       if resp.status == 200
         return resp.body

--- a/lib/identity-api-client/actions.rb
+++ b/lib/identity-api-client/actions.rb
@@ -42,7 +42,7 @@ module IdentityApiClient
     # This shares some logic with find_by above, but returns in the same format as the
     # 'recent...' methods below.
     #
-    def find_by_external_id(external_id, external_system)
+    def find_by_external_id(external_id:, external_system:)
       query_params = {
         external_id: external_id,
         external_system: external_system,


### PR DESCRIPTION
This PR goes with [Identity PR 3512 Add find_action_by_network_id API endpoint](https://github.com/the-open/identity/pull/3512).

It makes it possible to get data about Actions with a particular `external_id`.