### PR TITLE
Add ip_address to create_trace API

### DIFF
--- a/lib/identity-api-client/member.rb
+++ b/lib/identity-api-client/member.rb
@@ -29,12 +29,13 @@ module IdentityApiClient
     end
 
     # Return true if the API call succeeded, false otherwise
-    def create_trace(email:, kind:, details:, happened_at:)
+    def create_trace(email:, kind:, happened_at:, details: '', ip_address: nil)
       payload = {
         email: email,
         kind: kind,
         details: details,
         happened_at: happened_at,
+        ip_address: ip_address,
         api_token: client.connection.configuration.options[:api_token]
       }
 


### PR DESCRIPTION
This is so we can shift Network Login events from being MemberActions to MemberTraces, and still maintain the geo-ip lookup functionality (which is currently only present when recording a MemberAction).

See also https://github.com/the-open/identity/pull/3623